### PR TITLE
Agregar Boton de Solo Guardar (sin imprimir el ticket)

### DIFF
--- a/Assets/JS/POS/App.js
+++ b/Assets/JS/POS/App.js
@@ -122,8 +122,10 @@ function recalculatePaymentAmount() {
     if (OrderCheckout.change >= 0) {
         UI.paymentAmountInput.value = OrderCheckout.payment;
         UI.orderSaveButton.removeAttribute('disabled');
+        UI.orderSaveNoPrintButton.removeAttribute('disabled');
     } else {
         UI.orderSaveButton.setAttribute('disabled', 'disabled');
+        UI.orderSaveNoPrintButton.setAttribute('disabled', 'disabled');
     }
 
     UI.checkoutChangeDisplay.textContent = Core.roundDecimals(OrderCheckout.change);
@@ -138,6 +140,16 @@ function onCheckoutConfirm() {
     };
 
     Core.saveOrder(OrderCart, payments, UI.mainForm);
+}
+
+function onCheckoutConfirmNoPrint() {
+    let payments = {
+        amount: UI.paymentAmountInput.value,
+        change: OrderCheckout.change || 0,
+        method: UI.paymentMethodSelect.value
+    };
+
+    Core.saveNoPrintOrder(OrderCart, payments, UI.mainForm);
 }
 
 function deleteOrderOnHold(target) {
@@ -216,6 +228,9 @@ UI.paymentMethodSelect.addEventListener('change', function () {
     return recalculatePaymentAmount();
 });
 UI.orderSaveButton.addEventListener('click', function () {
+    return onCheckoutConfirm();
+});
+UI.orderSaveNoPrintButton.addEventListener('click', function () {
     return onCheckoutConfirm();
 });
 UI.orderHoldButton.addEventListener('click', function () {

--- a/Assets/JS/POS/AppCore.js
+++ b/Assets/JS/POS/AppCore.js
@@ -54,6 +54,19 @@ export function saveOrder(order, payments, form) {
     form.submit();
 }
 
+/* Guardar sin imprimir */
+export function saveNoPrintOrder(order, payments, form) {
+    const elements = form.elements;
+
+    elements.action.value = 'save-noprint-order';
+    elements.lines.value = JSON.stringify(order.lines);
+    elements.payments.value = JSON.stringify(payments);
+
+    //form.setAttribute('target', '_blank');
+
+    form.submit();
+}
+
 export function saveNewCustomer(taxID, name) {
     const data = new FormData();
 

--- a/Assets/JS/POS/AppUI.js
+++ b/Assets/JS/POS/AppUI.js
@@ -23,6 +23,7 @@ export const closeSessionButton = getElement('closeSessionButton');
 
 export const orderHoldButton = getElement('orderHoldButton');
 export const orderSaveButton = getElement('orderSaveButton');
+export const orderSaveNoPrintButton = getElement('orderSaveNoPrintButton');
 export const paymentAmountInput = getElement('paymentAmount');
 export const paymentMethodSelect = getElement('paymentMethod');
 export const checkoutChangeDisplay = getElement('paymentReturn');

--- a/Controller/POS.php
+++ b/Controller/POS.php
@@ -167,6 +167,10 @@ class POS extends Controller
             case 'save-order':
                 $this->saveOrder();
                 break;
+            
+            case 'save-noprint-order':
+            $this->saveNoPrintOrder();
+            break;
 
             case 'delete-order-on-hold':
                 $this->deleteOrderOnHold();

--- a/Controller/POS.php
+++ b/Controller/POS.php
@@ -287,7 +287,25 @@ class POS extends Controller
 
         return false;
     }
+    /**
+     * Save order and payments without print boucher.
+     */
+    protected function saveNoPrintOrder(): bool
+    {
+        if (false === $this->validateOrderRequest()) return false;
 
+        $orderRequest = new OrderRequest($this->request);
+        $order = new Order($orderRequest);
+
+        if ($this->getStorage()->placeOrder($order)) {
+            $this->toolBox()->i18nLog()->info('pos-order-ok');
+
+            return true;
+        }
+
+        return false;
+    }
+    
     /**
      * Close current user POS session.
      */

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # POS
 POS plugin for [Facturascripts 2021](https://www.facturascripts.com/) 
+Añadidas algunas personalizaciones para el mercado Dominicano

--- a/Translation/es_ES.json
+++ b/Translation/es_ES.json
@@ -40,5 +40,13 @@
   "pos": "Punto de venta",
   "pos-settings": "Configuración del punto de venta",
   "payment-change": "Cambio",
-  "payment-received": "Pago recibido"
+  "payment-received": "Pago recibido",
+  
+  "select-cash-register": "Seleccionar terminal",
+  "cash-initial-amount-input": "Efectivo de apertura inicial",
+  "cashup-total": "balance total",
+  "empty-cart-list": "Carrito de compra vacio",
+  "ticket-on-hold": "Ticket en espera",
+  "pos-order-on-hold": "Orden en espera",
+  "pos-orders-on-hold": "Ordenes en espera"
 }

--- a/View/POS/Layout/Base.html.twig
+++ b/View/POS/Layout/Base.html.twig
@@ -68,7 +68,7 @@
 {% macro message(log, types, style) %}
     {% set messages = log.read('', types) %}
     {% if messages | length > 0 %}
-        <div class="toast mr-auto" role="alert" data-delay="2000">
+        <div class="toast mr-auto" role="alert" data-delay="20000">
             <div class="toast-header text-white bg-{{ style }} border-0">
                 <strong class="mr-auto">{{ style|capitalize }}</strong>
                 <button type="button" class="ml-2 mb-1 close" data-dismiss="toast" aria-label="Close">

--- a/View/POS/Modal/Checkout.html.twig
+++ b/View/POS/Modal/Checkout.html.twig
@@ -75,8 +75,11 @@
                         <button type="button" class="btn btn-warning mr-auto" id="orderHoldButton">
                             <i class="fas fa-pause" aria-hidden="true"></i>&nbsp;{{ i18n.trans("ticket-on-hold") }}
                         </button>
-                        <button type="button" class="btn btn-primary" id="orderSaveButton" disabled="disabled">
-                            Guardar
+                        <button type="button" class="btn btn-primary mx-2" id="orderSaveButton" disabled="disabled">
+                            Imprimir y Guardar
+                        </button>
+                        <button type="button" class="btn btn-success" id="orderSaveNoPrintButton" disabled="disabled">
+                            Solo Guardar
                         </button>
                     </div>
                 </div>


### PR DESCRIPTION
Con esta modificacion se crean algunas funciones sobre la base de permitir guardar la orden de venta sin imprimir el ticket, esto a solicitud de un cliente en mi pais cuyo negocio no siempre tiene que imprimir el ticket de venta.