### PR TITLE
Correcciones para compatibilidad con PostgreSQL

### DIFF
--- a/Assets/JS/POS/modules/Cart.js
+++ b/Assets/JS/POS/modules/Cart.js
@@ -7,7 +7,7 @@ const Cart = new CartClass({
         'codserie': settings.serie,
         'codalmacen': settings.warehouse,
         'codcliente': settings.customer,
-        'idpausada': 'false',
+        'idpausada': 0,
         'tipo-documento': settings.document
     },
     'token': settings.token

--- a/Model/Join/ProductoVariante.php
+++ b/Model/Join/ProductoVariante.php
@@ -43,7 +43,7 @@ class ProductoVariante extends JoinModel
             'description' => 'P.descripcion',
             'price' => 'V.precio',
             'stock' => 'SUM(S.disponible)',
-            'detail' => 'CONCAT_WS(" - ", A1.descripcion, A2.descripcion, A3.descripcion, A4.descripcion)',
+            'detail' => 'CONCAT_WS(\' - \', A1.descripcion, A2.descripcion, A3.descripcion, A4.descripcion)',
             'atribute1' => 'A1.descripcion',
             'atribute2' => 'A2.descripcion',
             'atribute3' => 'A3.descripcion',
@@ -53,7 +53,7 @@ class ProductoVariante extends JoinModel
 
     protected function getGroupFields(): string
     {
-        return 'V.referencia';
+        return 'p.idproducto, V.referencia, V.codbarras, P.descripcion, V.precio, CONCAT_WS(\' - \', A1.descripcion, A2.descripcion, A3.descripcion, A4.descripcion), a1.descripcion, a2.descripcion, a3.descripcion, a4.descripcion';
     }
 
     /**


### PR DESCRIPTION
Se realizaron correcciones a 2 archivos:

En Assets\JS\POS\modules\Cart.js, la variable idpausada decia false, pero el campo es tipo integer, por lo que se cambió a 0.
En Model/Join/ProductoVariante.php se corrigió el formato de CONCAT_WS para que sea compatible con postgresql y se corrigió el group by para que contenga todos los campos del select.